### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Solidity LaTeX Highlighting
+
 Solidity is a major programming language for [Ethereum](https://ethereum.org/) smart contracts.
 **Solidity LaTeX highlighting** helps researchers include readable code examples in their papers.
 Compared to [some](https://github.com/dccp/bachelor-thesis-report/blob/0852ba922aefa71d9c943cbff363f40685345fe3/include/settings/Settings.tex) [other](https://github.com/adrianwersching/ustutt-fachstudie-dapps/blob/6673825f916c5a98462c8291b1814f7ed0e23417/ausarbeitung/ausarbeitung.tex) [previous](https://github.com/dybber/blockchain-summerschool-2016/blob/440259e1c41f1efa175a0e782e5420a732cd0008/tex/master.tex) [attempts](https://github.com/DCReum/dcreum.github.io/blob/724c00d20801cefd977c26e475ddac08e33763a8/docs/report.tex), this highlighter fully supports the [Solidity syntax](https://solidity.readthedocs.io/) (if you think this is not the case, feel free to submit an issue or a pull request).
@@ -6,7 +8,7 @@ Compared to [some](https://github.com/dccp/bachelor-thesis-report/blob/0852ba922
 
 ## Source
 
-```
+```latex
 \documentclass{article}
 
 \input{solidity-highlighting.tex}	% copy the file from this repo


### PR DESCRIPTION
Adds `latex` as language to the markdown code snippet. See [MD040](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040) for details.