### PR TITLE
Extract listings-solidity.sty file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,27 @@ Compared to [some](https://github.com/dccp/bachelor-thesis-report/blob/0852ba922
 ```latex
 \documentclass{article}
 
-\input{solidity-highlighting.tex}	% copy the file from this repo
+\usepackage{listings}
+\usepackage{listings-solidity} % copy listings-solidity.sty to your project
+
+\usepackage{xcolor}
+\definecolor{verylightgray}{rgb}{.97,.97,.97}
+
+\lstset{ % define general preferences
+	language=Solidity,
+	backgroundcolor=\color{verylightgray},
+	extendedchars=true,
+	basicstyle=\footnotesize\ttfamily,
+	showstringspaces=false,
+	showspaces=false,
+	numbers=left,
+	numberstyle=\footnotesize,
+	numbersep=9pt,
+	tabsize=2,
+	breaklines=true,
+	showtabs=false,
+	captionpos=b
+}
 
 \begin{lstlisting}[language=Solidity]
 pragma solidity 0.4.16;

--- a/examples.tex
+++ b/examples.tex
@@ -5,7 +5,27 @@
 
 \usepackage{filecontents, pgffor}
 
-\input{solidity-highlighting.tex}
+\usepackage{listings}
+\usepackage{listings-solidity} % copy listings-solidity.sty to your project
+
+\usepackage{xcolor}
+\definecolor{verylightgray}{rgb}{.97,.97,.97}
+
+\lstset{ % define general preferences
+	language=Solidity,
+	backgroundcolor=\color{verylightgray},
+	extendedchars=true,
+	basicstyle=\footnotesize\ttfamily,
+	showstringspaces=false,
+	showspaces=false,
+	numbers=left,
+	numberstyle=\footnotesize,
+	numbersep=9pt,
+	tabsize=2,
+	breaklines=true,
+	showtabs=false,
+	captionpos=b
+}
 
 \title{Solidity highlighting in LaTeX documents}
 \author{Sergei~Tikhomirov \\ \texttt{sergey.s.tikhomirov@gmail.com}}

--- a/listings-solidity.sty
+++ b/listings-solidity.sty
@@ -1,9 +1,7 @@
 % Copyright 2017 Sergei Tikhomirov, MIT License
 % https://github.com/s-tikhomirov/solidity-latex-highlighting/
 
-\usepackage{listings, xcolor}
-
-\definecolor{verylightgray}{rgb}{.97,.97,.97}
+\RequirePackage{listings}
 
 \lstdefinelanguage{Solidity}{
 	keywords=[1]{anonymous, assembly, assert, balance, break, call, callcode, case, catch, class, constant, continue, constructor, contract, debugger, default, delegatecall, delete, do, else, emit, event, experimental, export, external, false, finally, for, function, gas, if, implements, import, in, indexed, instanceof, interface, internal, is, length, library, log0, log1, log2, log3, log4, memory, modifier, new, payable, pragma, private, protected, public, pure, push, require, return, returns, revert, selfdestruct, send, solidity, storage, struct, suicide, super, switch, then, this, throw, transfer, true, try, typeof, using, value, view, while, with, addmod, ecrecover, keccak256, mulmod, ripemd160, sha256, sha3}, % generic keywords including crypto operations
@@ -20,20 +18,4 @@
 	stringstyle=\color{red}\ttfamily,
 	morestring=[b]',
 	morestring=[b]"
-}
-
-\lstset{
-	language=Solidity,
-	backgroundcolor=\color{verylightgray},
-	extendedchars=true,
-	basicstyle=\footnotesize\ttfamily,
-	showstringspaces=false,
-	showspaces=false,
-	numbers=left,
-	numberstyle=\footnotesize,
-	numbersep=9pt,
-	tabsize=2,
-	breaklines=true,
-	showtabs=false,
-	captionpos=b
 }


### PR DESCRIPTION
This PR proposes a change to follow the `.sty + .tex` style similar in https://github.com/julienc91/listings-golang. 
It extracts a `.sty` file that defines the solidity language (the user can safely upgrade this file to the latest version from the repo), merging `\lstset` into the main tex file since it contains user-specific preferences (so custom preferences won't be overwritten with updates). 
